### PR TITLE
Add files via upload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: wordcloud
 Type: Package
 Title: Word Clouds
-Version: 2.5
-Date: 2013-04-11
+Version: 2.6
+Date: 2018-06-17
 Author: Ian Fellows
 Maintainer: Ian Fellows <ian@fellstat.com>
 Description: Functionality to create pretty word clouds, visualize differences and similarity between documents, and avoid over-plotting in scatter plots with text.
@@ -11,5 +11,5 @@ LazyLoad: yes
 Depends: methods, RColorBrewer
 Imports: slam, Rcpp (>= 0.9.4)
 Suggests: tm (>= 0.6)
-URL: http://blog.fellstat.com/?cat=11 http://www.fellstat.com http://research.cens.ucla.edu/
+URL: http://blog.fellstat.com/?cat=11 http://www.fellstat.com
 LinkingTo: Rcpp

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,3 +4,7 @@ import( Rcpp )
 import( slam )
 import(methods)
 import(RColorBrewer)
+importFrom("graphics", "lines", "par", "plot", "plot.new",
+             "plot.window", "points", "rect", "strheight", "strwidth",
+             "text")
+importFrom("stats", "runif", "sd")

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -170,7 +170,8 @@ commonality.cloud <- function(term.matrix,comonality.measure=min,max.words=300,.
 
 #a cloud comparing the frequencies of words across documents
 comparison.cloud <- function(term.matrix,scale=c(4,.5),max.words=300,random.order=FALSE,
-		rot.per=.1,colors=brewer.pal(ncol(term.matrix),"Dark2"),use.r.layout=FALSE,title.size=3,...) { 
+		rot.per=.1,colors=brewer.pal(ncol(term.matrix),"Dark2"),use.r.layout=FALSE,title.size=3,
+		title.color=NULL,match.colors=FALSE,title.bg.color="grey90",...) { 
 	
 	ndoc <- ncol(term.matrix)
 	thetaBins <- seq(from=0,to=2*pi,length=ndoc+1)
@@ -250,8 +251,16 @@ comparison.cloud <- function(term.matrix,scale=c(4,.5),max.words=300,random.orde
 		ht <- strheight(word,cex=title.size)*1.2	
 		x1 <- .5+.45*cos(th)
 		y1 <- .5+.45*sin(th)
-		rect(x1-.5*wid,y1-.5*ht,x1+.5*wid,y1+.5*ht,col="grey90", border="transparent")
-		text(x1,y1,word,cex=title.size)
+		rect(x1-.5*wid,y1-.5*ht,x1+.5*wid,y1+.5*ht,col=title.bg.color, border="transparent")
+		if(is.null(title.color)){
+			if(match.colors){
+				text(x1,y1,word,cex=title.size,col=colors[i])
+			}else{
+				text(x1,y1,word,cex=title.size)
+			}
+		}else{
+			text(x1,y1,word,cex=title.size,col=title.color)
+		}
 		boxes[[length(boxes)+1]] <- c(x1-.5*wid,y1-.5*ht,wid,ht)
 	}
 	

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -171,7 +171,7 @@ commonality.cloud <- function(term.matrix,comonality.measure=min,max.words=300,.
 #a cloud comparing the frequencies of words across documents
 comparison.cloud <- function(term.matrix,scale=c(4,.5),max.words=300,random.order=FALSE,
 		rot.per=.1,colors=brewer.pal(ncol(term.matrix),"Dark2"),use.r.layout=FALSE,title.size=3,
-		title.color=NULL,match.colors=FALSE,title.bg.color="grey90",...) { 
+		title.colors=NULL,match.colors=FALSE,title.bg.colors="grey90",...) {
 	
 	ndoc <- ncol(term.matrix)
 	thetaBins <- seq(from=0,to=2*pi,length=ndoc+1)
@@ -244,22 +244,26 @@ comparison.cloud <- function(term.matrix,scale=c(4,.5),max.words=300,random.orde
 	
 	#add titles
 	docnames <- colnames(term.matrix)
-	for(i in 1:ncol(term.matrix)){
+	if(!is.null(title.colors)){
+		title.colors <- rep(title.colors, length.out=ndoc)
+	}
+	title.bg.colors <- rep(title.bg.colors, length.out=ndoc)
+	for(i in 1:ndoc){
 		th <- mean(thetaBins[i:(i+1)])
 		word <- docnames[i]
 		wid <- strwidth(word,cex=title.size)*1.2
 		ht <- strheight(word,cex=title.size)*1.2	
 		x1 <- .5+.45*cos(th)
 		y1 <- .5+.45*sin(th)
-		rect(x1-.5*wid,y1-.5*ht,x1+.5*wid,y1+.5*ht,col=title.bg.color, border="transparent")
-		if(is.null(title.color)){
+		rect(x1-.5*wid,y1-.5*ht,x1+.5*wid,y1+.5*ht,col=title.bg.colors[i], border="transparent")
+		if(is.null(title.colors)){
 			if(match.colors){
 				text(x1,y1,word,cex=title.size,col=colors[i])
 			}else{
 				text(x1,y1,word,cex=title.size)
 			}
 		}else{
-			text(x1,y1,word,cex=title.size,col=title.color)
+			text(x1,y1,word,cex=title.size,col=title.colors[i])
 		}
 		boxes[[length(boxes)+1]] <- c(x1-.5*wid,y1-.5*ht,wid,ht)
 	}

--- a/man/comparison.cloud.Rd
+++ b/man/comparison.cloud.Rd
@@ -7,10 +7,12 @@
   Plot a cloud comparing the frequencies of words across documents.
 }
 \usage{
-comparison.cloud(term.matrix,scale=c(4,.5),max.words=300,
-	random.order=FALSE,rot.per=.1,
+comparison.cloud(term.matrix,scale=c(4,.5), max.words=300,
+	random.order=FALSE, rot.per=.1,
 	colors=brewer.pal(ncol(term.matrix),"Dark2"),
-	use.r.layout=FALSE,title.size=3,...)
+	use.r.layout=FALSE, title.size=3,
+	title.colors=NULL, match.colors=FALSE,
+	title.bg.colors="grey90", ...)
 }
 \arguments{
   \item{term.matrix}{A term frequency matrix whose rows represent words and whose columns represent documents.}
@@ -18,15 +20,20 @@ comparison.cloud(term.matrix,scale=c(4,.5),max.words=300,
   \item{max.words}{Maximum number of words to be plotted. least frequent terms dropped}
   \item{random.order}{plot words in random order. If false, they will be plotted in decreasing frequency}
   \item{rot.per}{proportion words with 90 degree rotation}
-  \item{colors}{color words from least to most frequent}
+  \item{colors}{Color words in the order of columns in \code{term.matrix}}
   \item{use.r.layout}{if false, then c++ code is used for collision detection, otherwise R is used}
   \item{title.size}{Size of document titles}
+  \item{title.colors}{Colors used for document titles. See details.}
+  \item{match.colors}{Logical: should colors document titles colors match word colors? See details.}
+  \item{title.bg.colors}{Colors used for the background of document titles.}
   \item{...}{Additional parameters to be passed to text (and strheight,strwidth).}
 }
 \details{
 Let \eqn{p_{i,j}} be the rate at which word i occurs in document j, and \eqn{p_j} be the
 average across documents(\eqn{\sum_ip_{i,j}/ndocs}). The size of each word is mapped to its maximum deviation
 ( \eqn{max_i(p_{i,j}-p_j)} ), and its angular position is determined by the document where that maximum occurs.
+
+If \code{title.colors} is not \code{NULL}, it is used for document titles and \code{match.colors} is ignored.
 }
 \value{
 nothing
@@ -45,7 +52,11 @@ if(require(tm)){
 	term.matrix <- as.matrix(term.matrix)
 	colnames(term.matrix) <- c("SOTU 2010","SOTU 2011")
 	comparison.cloud(term.matrix,max.words=40,random.order=FALSE)
-	commonality.cloud(term.matrix,max.words=40,random.order=FALSE)
+	comparison.cloud(term.matrix,max.words=40,random.order=FALSE,
+		title.colors=c("red","blue"),title.bg.colors=c("grey40","grey70"))
+	comparison.cloud(term.matrix,max.words=40,random.order=FALSE,
+		match.colors=TRUE)
+
 }
 
 }


### PR DESCRIPTION
Match title colors in comparison.cloud

Hi Ian we spoke earlier today.
I've added three arguments `title.bg.color`, `title.color`, `match.colors`. The first one is straightforward and defaults to the color in the existing code. If a title color is specified (not NULL) it is used and `match.colors` is ignored, otherwise `match.colors` is checked and if `TRUE` then the word colors are use for the titles. If `title.color` is NULL and `match.colors` is `FALSE` the call to `text` is the same as current.
My test battery is as follows:
```
comparison.cloud(term.matrix,max.words=40,
	random.order=FALSE)
comparison.cloud(term.matrix,max.words=40,
	random.order=FALSE,title.color="blue")
comparison.cloud(term.matrix,max.words=40,
	random.order=FALSE,title.bg.color="lightblue")
comparison.cloud(term.matrix,max.words=40,
	random.order=FALSE,title.bg.color="lightblue",title.color="red")
comparison.cloud(term.matrix,max.words=40,
	random.order=FALSE,title.bg.color="lightblue",title.color="red",match.colors=TRUE)
comparison.cloud(term.matrix,max.words=40,
	random.order=TRUE,title.bg.color="lightblue",match.colors=TRUE)
```

I am new to GitHub, writing package-level code, and open-source projects, so i hope this makes sense. If yes I'll update the man page as well. Otherwise, or if I can do anything else, let me know!

